### PR TITLE
add a beak at the end of customPosition command

### DIFF
--- a/tahoma.js
+++ b/tahoma.js
@@ -45,6 +45,7 @@ module.exports = function(RED) {
 					statusProgressText = "Going to "+ msg.payload.position +"%...";
 					statusDoneText = "Set to "+ msg.payload.position +"%";
 					expectedState = {open: true, position: msg.payload.position};
+                                        break;
 				case "stop":
 					commandName = "stop";
 					statusProgressText = "Stopping...";


### PR DESCRIPTION
This is a bugfix to get the customPosition command running again. A beak was missing at the end of the section which ended up in a immediately stop command right after the customPosition command has been called.