### PR TITLE
supporting door handle state property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0.1] - 2019-08-21
+
+### Changed
+
+- Added door handle state support, contributed by [@matthub](https://github.com/matthub)
+
 ## [1.0.0] - 2018-12-13
 
 ### Changed
@@ -15,7 +21,6 @@ All notable changes to this project will be documented in this file.
 - New node `tahoma-read` (See [#6](https://github.com/nikkow/node-red-contrib-tahoma/issues/6))
 - New `stop` action to immediatly stop the current action on the devices (See [#5](https://github.com/nikkow/node-red-contrib-tahoma/pull/5), thanks to [@Genosse274](https://github.com/Genosse274))
 - New CHANGELOG.md file to keep track of all updates.
-
 
 ### Changed
 

--- a/core/tahomalink.js
+++ b/core/tahomalink.js
@@ -106,6 +106,12 @@ var getDeviceState = function getDeviceState(deviceURL) {
           if (_thisDevice.states[j].name === 'core:LuminanceState') {
             response.luminance = _thisDevice.states[j].value;
           }
+
+          // - Exposes door handle value
+          if (_thisDevice.states[j].name ===
+              'core:ThreeWayHandleDirectionState') {
+            response.handleState = _thisDevice.states[j].value;
+          }
         }
 
         return deferred.resolve(response);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-tahoma",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-tahoma",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Control a Somfy Tahoma box from Node RED",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
* Added processing for the state `core:ThreeWayHandleDirectionState` to support a door handle, result will be stored in property `handleState` within the response object, value could be `closed` for example
* Run `npm run pretest` without any errors
* Bumped version to 1.0.1 and updated changelog